### PR TITLE
Stop building old releases

### DIFF
--- a/.github/workflows/build-container-image.yml
+++ b/.github/workflows/build-container-image.yml
@@ -24,11 +24,6 @@ jobs:
     strategy:
       matrix:
         openstack_version:
-          - rocky
-          - stein
-          - train
-          - ussuri
-          - victoria
           - wallaby
           - xena
           - yoga
@@ -51,4 +46,6 @@ jobs:
           DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
           VERSION: ${{ matrix.openstack_version }}
           REPOSITORY: osism/openstackclient
-        if: github.ref == 'refs/heads/main'
+        if: |
+          github.repository == 'osism/container-image-openstackclient' &&
+          github.ref == 'refs/heads/main'

--- a/Containerfile
+++ b/Containerfile
@@ -27,8 +27,6 @@ RUN apk add --no-cache \
          grep -q "$package" /requirements/upper-constraints.txt && \
          echo "$package" >> /packages.txt || true; \
        done < /requirements.txt \
-    && if [ $VERSION = "rocky" ]; then sed -i '/^python-vitrageclient/d' /requirements/upper-constraints.txt; echo 'python-vitrageclient===2.7.0' >> /requirements/upper-constraints.txt; fi \
-    && if [ $VERSION = "rocky" ]; then sed -i '/^cmd2/d' /requirements/upper-constraints.txt; echo 'cmd2===0.8.9' >> /requirements/upper-constraints.txt; fi \
     && pip3 --no-cache-dir install --upgrade pip \
     && pip3 --no-cache-dir install -c /requirements/upper-constraints.txt -r /packages.txt \
     && pip3 --no-cache-dir install -c /requirements/upper-constraints.txt ospurge \


### PR DESCRIPTION
We no longer need to build old releases regularly, drop victoria and
older. Newer OSC versions should still be able to work with older
clouds.

Don't push images if we are forked.

Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>